### PR TITLE
refactor: configure Scalar UI options

### DIFF
--- a/src/Conways.GameOfLife.API/Extensions/WebApplicationExtensions.cs
+++ b/src/Conways.GameOfLife.API/Extensions/WebApplicationExtensions.cs
@@ -1,10 +1,25 @@
 using Asp.Versioning;
 using Asp.Versioning.Builder;
+using Scalar.AspNetCore;
 
 namespace Conways.GameOfLife.API.Extensions;
 
 internal static class WebApplicationExtensions
 {
+    internal static WebApplication MapOpenApiUI(this WebApplication app)
+    {
+        app.MapScalarApiReference(options =>
+        {
+            options.WithTheme(ScalarTheme.DeepSpace)
+                .WithTitle("Conway's Game of Life")
+                .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
+                .WithDownloadButton(showDownloadButton: true)
+                .WithDotNetFlag(expose: true);
+        });
+
+        return app;
+    }
+
     internal static RouteGroupBuilder MapApiGroup(this WebApplication app, ApiVersion version)
     {
         var versionSet = app.BuildApiVersionSet(version);

--- a/src/Conways.GameOfLife.API/Program.cs
+++ b/src/Conways.GameOfLife.API/Program.cs
@@ -26,7 +26,7 @@ var app = builder.Build();
 
 app.MapDefaultHealthChecks();
 app.MapOpenApi();
-app.MapScalarApiReference();
+app.MapOpenApiUI();
 app.UseMiddleware<ExceptionMiddleware>();
 
 var api = app.MapApiGroup(v1);


### PR DESCRIPTION
Configured the Scalar UI options to use C# HTTP Client as an example, and create a new extension to abstract OpenUI interface setup when invoking general `WebApplication` mappings on `Program.cs`

## Issue

Resolves #27 

## Checklist :white_check_mark:

- [x] My code adheres to the project's style guidelines.
- [x] I have reviewed my code thoroughly.
- [x] I have updated the documentation accordingly.
- [x] My changes do not introduce any new warnings.
- [x] I have added tests to verify the effectiveness of my fix or feature.
- [x] All new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## How Has This Been Tested? :test_tube:

Excute the project and checking the settings on Scalar UI.